### PR TITLE
Handle new sublime syntax: bash

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -26,7 +26,7 @@ from SublimeLinter.lint import Linter
 class Shellcheck(Linter):
     """Provides an interface to shellcheck."""
 
-    syntax = 'shell-unix-generic'
+    syntax = ('shell-unix-generic', 'bash')
     cmd = 'shellcheck --format gcc -'
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '


### PR DESCRIPTION
Sublime 3148 introduce a new syntax for shell script. It's called 'bash'.
```
> view.settings().get('syntax')
'Packages/ShellScript/Bash.sublime-syntax'
```