### PR TITLE
Fixed typo in the --format option. Equals sign was missing

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -5,7 +5,7 @@ import sublime
 
 class Shellcheck(Linter):
 
-    cmd = 'shellcheck --format gcc -'
+    cmd = 'shellcheck --format=gcc -'
     if sublime.platform() == 'windows' and which('wsl'):
         cmd = 'wsl ' + cmd
 


### PR DESCRIPTION
When I added command arguments to my configuration spellcheck reported a command line error because you need to have the equal sign (--format=gcc) to read the format setting correctly 