### PR TITLE
Add support for shellcheck installed natively in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install `shellcheck`, follow the instructions on [the shellcheck GitHub repos
 
 `shellcheck` can be installed with ``apt-get`` on Debian sid, ``brew`` on Mac OS X, or compiled from its Haskell sources (manually, or through `cabal`). 
 
-On Windows, the Linux Subsystem must be enabled. See [Microsoft's guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10), then run `wsl sudo apt update` and `wsl sudo apt install shellcheck` to install Shellcheck (if you installed ubuntu).
+On Windows either install natively or use the Linux Subsystem. See [Microsoft's guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10), then run `wsl sudo apt update` and `wsl sudo apt install shellcheck` to install Shellcheck (if you installed Ubuntu).
 
 On native Linux systems, Please make sure that the path to `shellcheck` is available to SublimeLinter.
 The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/latest/troubleshooting.html#finding-a-linter-executable).

--- a/linter.py
+++ b/linter.py
@@ -6,7 +6,7 @@ import sublime
 class Shellcheck(Linter):
 
     cmd = 'shellcheck --format=gcc -'
-    if sublime.platform() == 'windows' and which('wsl'):
+    if sublime.platform() == 'windows' and not which('shellcheck') and which('wsl'):
         cmd = 'wsl ' + cmd
 
     regex = (


### PR DESCRIPTION
The official shellcheck install instructions have options for installing through Scoop or by downloading a native binary for Windows. This means that WSL is not required.

This PR first checks for shellcheck on the PATH, then tries wsl