### PR TITLE
remove trailing dash from cmd

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -5,7 +5,7 @@ import sublime
 
 class Shellcheck(Linter):
 
-    cmd = 'shellcheck --format=gcc -'
+    cmd = 'shellcheck --format=gcc'
     if sublime.platform() == 'windows' and not which('shellcheck') and which('wsl'):
         cmd = 'wsl ' + cmd
 

--- a/linter.py
+++ b/linter.py
@@ -5,7 +5,7 @@ import sublime
 
 class Shellcheck(Linter):
 
-    cmd = 'shellcheck --format=gcc'
+    cmd = 'shellcheck --format=gcc ${args} -'
     if sublime.platform() == 'windows' and not which('shellcheck') and which('wsl'):
         cmd = 'wsl ' + cmd
 


### PR DESCRIPTION
Dash instructs shellcheck there are no options after the dash. But sometimes SublimeLinter provides args for shellcheck.
For example, I need shellcheck to follow `source` commands. It can be achieved with `-x` or `--external-sources` option:
```
$ shellcheck
No files specified.

Usage: shellcheck [OPTIONS...] FILES...
  -a                --check-sourced          Include warnings from sourced files
  -C[WHEN]          --color[=WHEN]           Use color (auto, always, never)
  -e CODE1,CODE2..  --exclude=CODE1,CODE2..  Exclude types of warnings
  -f FORMAT         --format=FORMAT          Output format (checkstyle, gcc, json, tty)
  -s SHELLNAME      --shell=SHELLNAME        Specify dialect (sh, bash, dash, ksh)
  -V                --version                Print version information
  -x                --external-sources       Allow 'source' outside of FILES
```
Next Setting will work only if there is no trailing dash in cmd:
```
// SublimeLinter Settings - User
{
    "linters": {
        "shellcheck": {
            "args": "-x"
        }
    }
}
```
