### PR TITLE
Pass --external-sources to shellcheck

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -5,7 +5,7 @@ import sublime
 
 class Shellcheck(Linter):
 
-    cmd = 'shellcheck --format=gcc ${args} -'
+    cmd = 'shellcheck --external-sources --format=gcc ${args} -'
     if sublime.platform() == 'windows' and not which('shellcheck') and which('wsl'):
         cmd = 'wsl ' + cmd
 


### PR DESCRIPTION
Many shell scripts use "source" to include other scripts. This option
tells shellcheck to parse those external scripts, so that the remainder
of the script can be properly linted.