### PR TITLE
Remove warning in install.txt about no Windows installer

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -7,4 +7,3 @@ Please read the installation instructions at:
 https://github.com/SublimeLinter/SublimeLinter-shellcheck
 
 Follow install instructions of shellcheck at https://github.com/koalaman/shellcheck
-There is no Windows installer.


### PR DESCRIPTION
PR removes warning in **messages/install.txt** about there not being a Windows installer.

A quick and easy install of shellcheck can be done with Chocolatey or Scoop, and there's a Windows executable on their [release assets](https://github.com/koalaman/shellcheck/releases).

Besides, **README.md** and **install.txt** already have links to the project page, where all necessary info is.
